### PR TITLE
local storage option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 node_modules
+local_storage

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: npm run start
+web: npm run start-prod

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 Create digestible and shareable Callgraph documents from Activity Monitor for profiling multi-threaded processes.
 
 https://callgraph.herokuapp.com/9f3d8a618c3a988e15d0e5832ecf016f
+
+# Develop
+
+```shell
+# install deps
+npm install
+
+# start a local server at localhost:5000
+# this will pass LOCAL_STORAGE=1 as an environment variable
+# which will use the local_storage/ directory to store callgraph files
+# instead of AWS S3
+npm start
+```

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js",
+    "start": "CALLGRAPH_LOCAL_STORAGE=1 node index.js",
+    "start-prod": "node index.js",
     "test": "tape test/*.test.js"
   },
   "keywords": [],


### PR DESCRIPTION
This allows the developer to use local storage instead of s3 when working (to work locally and avoid unnecessary s3 usages)

resolves #5 

This is now the default when running `npm start` - `npm run start-prod` is necessary for production s3.